### PR TITLE
DSP-1673 SearchResult should allow LI or DIV parent element

### DIFF
--- a/src/components/SearchResult/SearchResult.stories.tsx
+++ b/src/components/SearchResult/SearchResult.stories.tsx
@@ -9,7 +9,13 @@ const meta = {
     title: 'Components/Search results/Result',
     component: SearchResult,
     argTypes: {
-        children: argTypes.children()
+        children: argTypes.children(),
+        tagName: {
+            control: { type: 'select' },
+            description: 'HTML tag name to use for the search result',
+            options: ['li', 'div'],
+            type: 'string'
+        }
     },
     args: {
         title: 'Greenhouse gas statistics 1990-2022',

--- a/src/components/SearchResult/SearchResult.test.tsx
+++ b/src/components/SearchResult/SearchResult.test.tsx
@@ -30,6 +30,7 @@ test('search result renders correctly', () => {
     const searchResult = screen.getByTestId('searchresult');
     expect(searchResult).toHaveClass('ds_search-result');
     expect(searchResult).not.toHaveClass('ds_search-result--promoted');
+    expect(searchResult.tagName).toEqual('LI');
 
     const title = screen.getByRole('heading');
     expect(title).toHaveClass('ds_search-result__title');
@@ -195,6 +196,19 @@ test('linkComponent is used for title link', () => {
     expect(link.tagName).toBe('SPAN');
     expect(link?.parentElement).toEqual(title);
     expect(link?.previousElementSibling).toBeNull();
+});
+
+test('search result with DIV as tagName', () => {
+    render(
+        <SearchResult href={RESULT_HREF} title={RESULT_TITLE} data-testid="searchresult" tagName="div">
+            <SearchResult.Content>
+                {RESULT_CONTENT}
+            </SearchResult.Content>
+        </SearchResult>
+    );
+
+    const searchResult = screen.getByTestId('searchresult');
+    expect(searchResult.tagName).toEqual('DIV');
 });
 
 test('passing additional props', () => {

--- a/src/components/SearchResult/SearchResult.tsx
+++ b/src/components/SearchResult/SearchResult.tsx
@@ -1,5 +1,5 @@
 import { Children, createContext, useContext } from 'react';
-import ConditionalWrapper from '../../common/ConditionalWrapper';
+import { ConditionalWrapper, WrapperTag } from '../../common';
 import AspectBox from '../AspectBox';
 import Metadata from '../PageMetadata';
 import { SearchResultContextProps, SearchResultProps } from './types';
@@ -88,16 +88,18 @@ const SearchResult = ({
     isPromoted,
     linkComponent,
     promotedTitle = 'Recommended',
+    tagName = 'li',
     title,
     ...props
 }: SearchResultProps) => {
     const LINK_CLASS = 'ds_search-result__link';
 
     return (
-        <div className={clsx([
+        <WrapperTag className={clsx([
             'ds_search-result',
             isPromoted && 'ds_search-result--promoted'
         ])}
+            tagName={tagName}
             {...props}
         >
             <ConditionalWrapper
@@ -118,7 +120,7 @@ const SearchResult = ({
                     {children}
                 </SearchResultLinkHrefContext>
             </ConditionalWrapper>
-        </div>
+        </WrapperTag>
     );
 };
 

--- a/src/components/SearchResult/types.ts
+++ b/src/components/SearchResult/types.ts
@@ -5,9 +5,10 @@ export interface SearchResultContextProps extends React.AllHTMLAttributes<HTMLDL
 }
 
 export interface SearchResultProps extends React.AllHTMLAttributes<HTMLElement> {
-    href: string;
-    isPromoted?: boolean;
-    linkComponent?: LinkComponent;
-    promotedTitle?: string;
-    title: string;
+    href: string
+    isPromoted?: boolean
+    linkComponent?: LinkComponent
+    promotedTitle?: string
+    tagName?: 'div' | 'li'
+    title: string
 }


### PR DESCRIPTION
- add 'tagName' prop, defaulted to LI