### PR TITLE
DSP-1669 CookieBanner should be hidden by default

### DIFF
--- a/src/common/AbstractNotificationBanner/AbstractNotificationBanner.test.tsx
+++ b/src/common/AbstractNotificationBanner/AbstractNotificationBanner.test.tsx
@@ -103,6 +103,20 @@ test('abstract notification banner with buttons', () => {
     expect(buttonContainer?.previousElementSibling).toEqual(textContainer);
 });
 
+test('hidden abstract notification banner', () => {
+    render(
+        <AbstractNotificationBanner isHidden>
+            {NOTIFICATION_TEXT}
+        </AbstractNotificationBanner>
+    );
+
+    const bannerTitle = screen.getByRole('heading');
+    const bannerContent = bannerTitle.parentElement;
+    const bannerWrapper = bannerContent?.parentElement;
+    const bannerContainer = bannerWrapper?.parentElement;
+    expect(bannerContainer).toHaveClass('fully-hidden');
+});
+
 test('passing additional props', () => {
     render(
         <AbstractNotificationBanner data-test="foo">

--- a/src/common/AbstractNotificationBanner/AbstractNotificationBanner.tsx
+++ b/src/common/AbstractNotificationBanner/AbstractNotificationBanner.tsx
@@ -17,6 +17,7 @@ const AbstractNotificationBanner = ({
     hasInverseIcon,
     icon,
     isDismissable,
+    isHidden,
     title = 'Information',
     ...props
 }: AbstractNotificationBannerProps) => {
@@ -36,6 +37,7 @@ const AbstractNotificationBanner = ({
         <div
             className={clsx([
                 'ds_notification',
+                isHidden ? 'fully-hidden' : undefined,
                 className
             ])}
             data-module="ds-notification"

--- a/src/common/AbstractNotificationBanner/types.ts
+++ b/src/common/AbstractNotificationBanner/types.ts
@@ -1,13 +1,14 @@
 import { IconName } from '../../shared-types';
 
 export interface AbstractNotificationBannerProps extends React.AllHTMLAttributes<HTMLDivElement> {
-    hasIcon?: boolean;
-    hasColourIcon?: boolean;
-    hasInverseIcon?: boolean;
-    icon?: IconName;
-    isDismissable?: boolean;
-    title?: string;
-    ref?: React.Ref<HTMLDivElement>;
+    hasIcon?: boolean
+    hasColourIcon?: boolean
+    hasInverseIcon?: boolean
+    icon?: IconName
+    isDismissable?: boolean
+    isHidden?: boolean
+    title?: string
+    ref?: React.Ref<HTMLDivElement>
 }
 
 export interface AbstractNotificationBannerButtonsProps extends React.AllHTMLAttributes<HTMLDivElement> {

--- a/src/components/CookieBanner/CookieBanner.tsx
+++ b/src/components/CookieBanner/CookieBanner.tsx
@@ -8,6 +8,7 @@ import clsx from 'clsx';
 const CookieBanner = ({
     children,
     className,
+    isHidden = true,
     title = 'Information',
     ...props
 }: AbstractNotificationBannerProps) => {
@@ -30,6 +31,7 @@ const CookieBanner = ({
                     className
                 ])}
                 data-module="ds-cookie-notification"
+                isHidden={isHidden}
                 ref={ref}
                 title={title}
                 {...props}

--- a/src/components/NotificationBanner/NotificationBanner.test.tsx
+++ b/src/components/NotificationBanner/NotificationBanner.test.tsx
@@ -52,3 +52,16 @@ test('instantiating/initialising DS component script', () => {
     expect(notificationBanner).toHaveClass('js-initialised');
     expect(notificationBanner).toHaveClass('js-instantiated');
 });
+
+test('hidden notification banner', () => {
+    render(
+        <NotificationBanner isHidden>
+        </NotificationBanner>
+    );
+
+    const bannerTitle = screen.getByRole('heading');
+    const bannerContent = bannerTitle.parentElement;
+    const bannerWrapper = bannerContent?.parentElement;
+    const bannerContainer = bannerWrapper?.parentElement;
+    expect(bannerContainer).toHaveClass('fully-hidden');
+});

--- a/src/components/NotificationBanner/NotificationBanner.tsx
+++ b/src/components/NotificationBanner/NotificationBanner.tsx
@@ -11,6 +11,7 @@ const NotificationBanner = ({
     hasIcon,
     hasInverseIcon,
     isDismissable,
+    isHidden,
     title = 'Information',
     ...props
 }: AbstractNotificationBannerProps) => {
@@ -29,10 +30,11 @@ const NotificationBanner = ({
                 'ds_reversed',
                 className
             ])}
-            isDismissable={isDismissable}
             icon={hasIcon ? "Warning" : undefined}
             hasColourIcon={hasColourIcon}
             hasInverseIcon={hasInverseIcon}
+            isDismissable={isDismissable}
+            isHidden={isHidden}
             ref={ref}
             title={title}
             {...props}


### PR DESCRIPTION
- add 'isHidden' prop to AbstractNotificationBanner
- use 'isHidden' in CookieBanner and NotificationBanner