### PR TITLE
DSP-1670 PageHeader component to accept HTML in its title text

### DIFF
--- a/src/components/PageHeader/PageHeader.stories.tsx
+++ b/src/components/PageHeader/PageHeader.stories.tsx
@@ -9,6 +9,12 @@ const meta = {
     component: PageHeader,
     argTypes: {
         children: argTypes.children(),
+        heading: {
+            description: 'Text (allowing HTML/JSX) to use for the H1 element',
+            type: {
+                name: 'string'
+            }
+        },
         label: {
             description: 'Text to use for a label shown above the H1 element',
             type: 'string'
@@ -16,8 +22,7 @@ const meta = {
         title: {
             description: 'Text to use for the H1 element',
             type: {
-                name: 'string',
-                required: true
+                name: 'string'
             }
         }
     },

--- a/src/components/PageHeader/PageHeader.test.tsx
+++ b/src/components/PageHeader/PageHeader.test.tsx
@@ -3,16 +3,16 @@ import { render, screen, within } from '@testing-library/react';
 import PageHeader from './PageHeader';
 
 const LABEL_TEXT = 'Guide';
-const TITLE_TEXT = 'Apply for or renew a disabled parking permit';
+const HEADING_TEXT = 'Apply for or renew a disabled parking permit';
 
 test('notification banner renders correctly', () => {
     render(
-        <PageHeader label={LABEL_TEXT} title={TITLE_TEXT}/>
+        <PageHeader label={LABEL_TEXT} heading={HEADING_TEXT}/>
     );
 
     const header = screen.getByRole('banner');
-    const title = within(header).getByRole('heading');
-    const label = title.previousElementSibling;
+    const heading = within(header).getByRole('heading');
+    const label = heading.previousElementSibling;
 
     expect(header).toHaveClass('ds_page-header');
     expect(header.tagName).toEqual('HEADER');
@@ -21,26 +21,36 @@ test('notification banner renders correctly', () => {
     expect(label?.textContent).toEqual(LABEL_TEXT);
     expect(label?.tagName).toEqual('SPAN');
 
-    expect(title).toHaveClass('ds_page-header__title');
-    expect(title.textContent).toEqual(TITLE_TEXT);
-    expect(title.tagName).toEqual('H1');
+    expect(heading).toHaveClass('ds_page-header__title');
+    expect(heading.innerHTML).toEqual(HEADING_TEXT);
+    expect(heading.tagName).toEqual('H1');
+});
+
+test('header with title prop (legacy)', () => {
+    render(
+        <PageHeader label={LABEL_TEXT} title={HEADING_TEXT}/>
+    );
+
+    const header = screen.getByRole('banner');
+    const heading = within(header).getByRole('heading');
+    expect(heading.innerHTML).toEqual(HEADING_TEXT);
 });
 
 test('header with no label', () => {
     render(
-        <PageHeader title={TITLE_TEXT}/>
+        <PageHeader heading={HEADING_TEXT}/>
     );
 
     const header = screen.getByRole('banner');
-    const title = within(header).getByRole('heading');
-    const label = title.previousElementSibling;
+    const heading = within(header).getByRole('heading');
+    const label = heading.previousElementSibling;
 
     expect(label).not.toBeInTheDocument();
 });
 
 test('passing additional props', () => {
     render(
-       <PageHeader data-test="foo" label={LABEL_TEXT} title={TITLE_TEXT}/>
+       <PageHeader data-test="foo" label={LABEL_TEXT} heading={HEADING_TEXT}/>
     )
 
     const header = screen.getByRole('banner');
@@ -49,7 +59,7 @@ test('passing additional props', () => {
 
 test('passing additional CSS classes', () => {
     render(
-       <PageHeader className="foo" label={LABEL_TEXT} title={TITLE_TEXT}/>
+       <PageHeader className="foo" label={LABEL_TEXT} heading={HEADING_TEXT}/>
     )
 
     const header = screen.getByRole('banner');

--- a/src/components/PageHeader/PageHeader.tsx
+++ b/src/components/PageHeader/PageHeader.tsx
@@ -4,6 +4,7 @@ import clsx from 'clsx';
 const PageHeader = ({
     children,
     className,
+    heading,
     label,
     title,
     titleId,
@@ -18,7 +19,7 @@ const PageHeader = ({
             {...props}
         >
             {label && <span className="ds_page-header__label  ds_content-label">{label}</span>}
-            <h1 id={titleId} className="ds_page-header__title">{title}</h1>
+            <h1 id={titleId} className="ds_page-header__title">{heading || title}</h1>
 
             {children}
         </header>

--- a/src/components/PageHeader/types.ts
+++ b/src/components/PageHeader/types.ts
@@ -1,5 +1,6 @@
-export interface PageHeaderProps extends React.AllHTMLAttributes<HTMLHeadingElement> {
+export interface PageHeaderProps extends React.AllHTMLAttributes<HTMLElement> {
     label?: string;
-    title: string;
+    heading?: string | React.ReactNode;
+    title?: string
     titleId?: string;
 }


### PR DESCRIPTION
- add 'heading' prop to PageHeader that allows strings and markup
- component falls back to legacy 'title' attribute if 'heading' not set