### PR TITLE
DSP-1674 SummaryList - empty 'actions' container when no actions for a summary list item

### DIFF
--- a/src/components/SummaryCard/SummaryCard.test.tsx
+++ b/src/components/SummaryCard/SummaryCard.test.tsx
@@ -87,6 +87,24 @@ test('summary card with multiple actions renders actions as a list', () => {
     expect(actionsList.children[0].tagName).toEqual('LI');
 });
 
+test('summary card with no actions has no actions container', () => {
+    render(
+        <SummaryCard
+            data-testid="foo"
+            title={TITLE_TEXT}
+        >
+            <SummaryCard.Action href={ACTIONS[0].href}>{ACTIONS[0].title}</SummaryCard.Action>
+            <SummaryList data-testid="bar" />
+        </SummaryCard>
+    );
+
+    const summaryCard = screen.getByTestId('foo');
+    const title = within(summaryCard).getByRole('heading');
+    const header = title.parentElement as HTMLElement;
+    const actionsList = within(header).queryByRole('list')
+    expect(actionsList).not.toBeInTheDocument();
+});
+
 test('passing additional props', () => {
     render(
         <SummaryCard

--- a/src/components/SummaryCard/SummaryCard.tsx
+++ b/src/components/SummaryCard/SummaryCard.tsx
@@ -43,7 +43,7 @@ const SummaryCard = ({
                     tagName={headingLevel}
                 >{title}</WrapperTag>
 
-                {actions &&
+                {!!actions.length &&
                     <ConditionalWrapper
                         condition={actions.length > 1}
                         wrapper={(children: React.JSX.Element) => <ul className="ds_summary-card__actions-list">{children}</ul>}

--- a/src/components/SummaryList/SummaryList.test.tsx
+++ b/src/components/SummaryList/SummaryList.test.tsx
@@ -131,6 +131,19 @@ test('summary list item with multiple actions', () => {
     expect(actionsList?.children[1].textContent).toEqual(ITEM_ACTIONS[1].title);
 });
 
+test('summary list item with no actions has no actions container', () => {
+    render(
+        <SummaryList.Item title={TITLE}>
+            <SummaryList.Value>{VALUE_1}</SummaryList.Value>
+        </SummaryList.Item>
+    );
+
+    const item = screen.getAllByRole('listitem')[0];
+    const actions = item.querySelector('.ds_summary-list__actions');
+
+    expect(actions).not.toBeInTheDocument();
+});
+
 test('passing additional props', () => {
     render(
         <SummaryList data-test="foo" />

--- a/src/components/SummaryList/SummaryList.tsx
+++ b/src/components/SummaryList/SummaryList.tsx
@@ -42,7 +42,7 @@ const Item = ({
                     ))}
                 </ConditionalWrapper>
             </span>
-            {actions &&
+            {!!actions.length &&
                 <div className="ds_summary-list__actions">
                     <ConditionalWrapper
                         condition={actions.length > 1}


### PR DESCRIPTION
(also applies to SummaryCard)